### PR TITLE
Fixing Custom Directive Doc Hash

### DIFF
--- a/rules/vue/vue-directive.js
+++ b/rules/vue/vue-directive.js
@@ -10,7 +10,7 @@ module.exports = {
       fix: (
         'Check ' + chalk.red('Vue.directive(' + name + ')') + ' to make sure its syntax has been updated and for anything beyond simple DOM manipulations, refactor to a component'
       ),
-      docsHash: 'Custom-Directives',
+      docsHash: 'Custom-Directives-simplified',
       type: 'js'
     }
   }


### PR DESCRIPTION
The current hash is being redirected to https://vuejs.org/v2/guide/migration.html#Built-In-Directives but should go to https://vuejs.org/v2/guide/migration.html#Custom-Directives-simplified