### PR TITLE
Extended Vue and Vuex version checks from Vue v2 to v9 and Vuex v1 to v9

### DIFF
--- a/rules/vue/vue-dependency.js
+++ b/rules/vue/vue-dependency.js
@@ -3,7 +3,7 @@
 var chalk = require('chalk')
 
 module.exports = {
-  pattern: /("vue"\s*:\s*)"[^\d"]*?[^2]\.\d+\.\d+"/,
+  pattern: /("vue"\s*:\s*)"[^\d"]*?[^2-9]\.\d+\.\d+"/,
   warning: function (match, preVersion) {
     return {
       reason: 'If you are using pre-2.0 Vue through NPM, you have to update it in your package.json file',

--- a/rules/vue/vue-dependency.spec.js
+++ b/rules/vue/vue-dependency.spec.js
@@ -36,6 +36,20 @@ describe('Rule: vue-dependency', () => {
     expect(warning).toBe(null)
   })
 
+  it('is not limited to pre 3.0 versions', () => {
+    const warning = check(`
+      "vue": "3.0.0"
+    `)
+    expect(warning).toBe(null)
+  })
+
+  it('is not limited to pre 3.0 versions, with comma', () => {
+    const warning = check(`
+      "vue": "3.0.0",
+    `)
+    expect(warning).toBe(null)
+  })
+
   it('does not match vuex "1.0.0"', () => {
     const warning = check(`
       "vuex": "1.0.0"

--- a/rules/vuex/vuex-dependency.js
+++ b/rules/vuex/vuex-dependency.js
@@ -3,7 +3,7 @@
 var chalk = require('chalk')
 
 module.exports = {
-  pattern: /("vuex"\s*:\s*)"[^\d"]*?[^1-2]\.\d+\.\d+"/,
+  pattern: /("vuex"\s*:\s*)"[^\d"]*?[^1-9]\.\d+\.\d+"/,
   warning: function (match, preVersion) {
     return {
       reason: 'Vuex 1.0 is the earliest supported version compatible with Vue 2.0',


### PR DESCRIPTION
Here's the PR for https://github.com/vuejs/vue-migration-helper/issues/42

I know it's pretty wide version range, but I don't believe it'll be a problem ever.