### PR TITLE
update url of migration guide

### DIFF
--- a/helpers/migration-guide-url-for.js
+++ b/helpers/migration-guide-url-for.js
@@ -2,8 +2,8 @@
 
 module.exports = function (library) {
   if (library === 'vue') {
-    return 'http://vuejs.org/guide/migration.html'
+    return 'https://v2.vuejs.org/v2/guide/migration'
   } else {
-    return 'http://vuejs.org/guide/migration-' + library + '.html'
+    return 'https://v2.vuejs.org/v2/guide/migration-' + library
   }
 }

--- a/helpers/migration-guide-url-for.spec.js
+++ b/helpers/migration-guide-url-for.spec.js
@@ -6,15 +6,15 @@ describe('Helper: migration-guide-url-for', () => {
   it('returns the main migration guide for vue', () => {
     expect(
       migrationGuideUrlFor('vue')
-    ).toBe('http://vuejs.org/guide/migration.html')
+    ).toBe('https://v2.vuejs.org/v2/guide/migration')
   })
 
   it('returns a suffixed migration guide for companion libraries', () => {
     expect(
       migrationGuideUrlFor('vue-router')
-    ).toBe('http://vuejs.org/guide/migration-vue-router.html')
+    ).toBe('https://v2.vuejs.org/v2/guide/migration-vue-router')
     expect(
       migrationGuideUrlFor('vuex')
-    ).toBe('http://vuejs.org/guide/migration-vuex.html')
+    ).toBe('https://v2.vuejs.org/v2/guide/migration-vuex')
   })
 })

--- a/helpers/report-warning.spec.js
+++ b/helpers/report-warning.spec.js
@@ -22,7 +22,7 @@ describe('Helper: report-warning', () => {
 1. ddd
   Line bbb: /foo/bar/baz.js
   Reason: ccc
-  More info: http://vuejs.org/guide/migration-yyy.html#eee`)
+  More info: https://v2.vuejs.org/v2/guide/migration-yyy#eee`)
   })
 
   it('prints the correct output for a simple vue deprecation', () => {
@@ -44,6 +44,6 @@ describe('Helper: report-warning', () => {
 2. ddd
   Line bbb: /foo/bar/baz.js
   Reason: ccc
-  More info: http://vuejs.org/guide/migration.html#eee`)
+  More info: https://v2.vuejs.org/v2/guide/migration#eee`)
   })
 })


### PR DESCRIPTION
- Replace all hard-coded Vue 2 migration links with https://v2.vuejs.org/...
- Drop obsolete “.html” suffixes in the paths

Almost nobody is upgrading a legacy Vue 1.x project in 2025, so this may never get merged. But if someone else does stumble down this path, I hope this PR helps them too.